### PR TITLE
Utilise le RSA sur la même période que l'ASPA

### DIFF
--- a/openfisca_paris/aspeh.py
+++ b/openfisca_paris/aspeh.py
@@ -7,6 +7,18 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 # Allocation de soutien aux parents d’enfants handicapés
 
+class paris_logement_aspeh_base_ressources(Variable):
+    value_type = float
+    label = u"Base ressources pour l'Allocation de soutien aux parents d’enfants handicapés"
+    entity = Famille
+    definition_period = MONTH
+
+    def formula(famille, period, legislation):
+        base_ressources = famille('paris_base_ressources_couple', period.last_month)
+        clca = famille('paje_clca', period.last_month)
+        return base_ressources + clca
+
+
 class paris_logement_aspeh(Variable):
     value_type = float
     label = u"Le montant de l'Allocation de soutien aux parents d’enfants handicapés"
@@ -14,21 +26,11 @@ class paris_logement_aspeh(Variable):
     definition_period = MONTH
 
     def formula(famille, period, legislation):
-        last_month = period.last_month
-
         plafond_aspeh = legislation(period).paris.aspeh.plafond_aspeh
-        aide_aspeh = legislation(period).paris.aspeh.aide_aspeh
+        montant = legislation(period).paris.aspeh.aide_aspeh
 
         parisien = famille('parisien', period)
+        nb_enfant_handicape = famille('paris_nb_enfants_handicapes', period)
+        ressources = famille('paris_logement_aspeh_base_ressources', period)
 
-        enfant_handicape = famille.members('paris_enfant_handicape', period)
-        nb_enfant = famille.sum(enfant_handicape)
-
-        base_ressources = famille('paris_base_ressources_couple', last_month)
-        clca = famille('paje_clca', last_month)
-
-        ressources_mensuelles_famille = base_ressources + clca
-
-        result = select([ressources_mensuelles_famille <= plafond_aspeh],
-            [aide_aspeh]) * parisien
-        return result * nb_enfant
+        return parisien * (ressources <= plafond_aspeh) * nb_enfant_handicape * montant

--- a/openfisca_paris/paris.py
+++ b/openfisca_paris/paris.py
@@ -69,7 +69,7 @@ class paris_base_ressources_famille(Variable):
 
     def formula(famille, period):
         aspa = famille('aspa', period)
-        rsa = famille('rsa', period.last_month)
+        rsa = famille('rsa', period)
         return aspa + rsa
 
 class paris_base_ressources_couple(Variable):

--- a/tests/unittests/aspeh.yaml
+++ b/tests/unittests/aspeh.yaml
@@ -1,151 +1,38 @@
 - name: Famille éligible pour l'allocation de soutien aux parents d’enfants handicapés
   period: 2016-02
   input:
-    famille:
-      parents: [couple1, couple2]
-      enfants: [enfant1, enfant2, enfant3]
-      parisien: true
-    menage:
-      statut_occupation_logement: locataire_vide
-      personne_de_reference: couple1
-      conjoint: couple2
-      enfants: [enfant1, enfant2, enfant3]
-    individus:
-      couple1:
-        age: 55
-        salaire_net:
-          2016-01: 3100
-      couple2:
-        age: 55
-        chomage_net:
-          2016-01: 1400
-      enfant1:
-        age: 5
-      enfant2:
-        age: 7
-      enfant3:
-        age: 9
-        handicap: true
-    foyers_fiscaux:
-      foyer_fiscal_0:
-        declarants:
-        - couple1
-        - couple2
-        personnes_a_charge:
-        - enfant1
-        - enfant2
-        - enfant3
+    parisien: true
+    paris_logement_aspeh_base_ressources: 4500
+    paris_nb_enfants_handicapes: 1
   output:
     paris_logement_aspeh: 153
 
-- name: Famille non éligible pour l'allocation de soutien aux parents d’enfants handicapés
+- name: Famille sans enfant handicapé non éligible à l'allocation de soutien aux parents d’enfants handicapés
   period: 2016-02
   input:
-    famille:
-      parents: [couple1, couple2]
-      enfants: [enfant1]
-      parisien: true
-      paje_clca: 1000
-    menage:
-      statut_occupation_logement: locataire_vide
-      personne_de_reference: couple1
-      conjoint: couple2
-      enfants: [enfant1]
-    individus:
-      couple1:
-        age: 55
-        salaire_net:
-          2016-01: 1100
-      couple2:
-        age: 55
-        chomage_net:
-          2016-01: 400
-      enfant1:
-        age: 5
-    foyers_fiscaux:
-      foyer_fiscal_0:
-        declarants:
-        - couple1
-        - couple2
-        personnes_a_charge:
-        - enfant1
+    parisien: true
+    paris_logement_aspeh_base_ressources: 4500
+    paris_nb_enfants_handicapes: 0
   output:
     paris_logement_aspeh: 0
 
-- name: Famille non éligible pour l'allocation de soutien aux parents d’enfants handicapés
+- name: Famille aux ressources trop élevées pour l'allocation de soutien aux parents d’enfants handicapés
   period: 2016-02
   input:
-    famille:
-      parents: [couple1, couple2]
-      enfants: [enfant1, enfant2]
-      parisien: true
-      paje_clca: 100
-    menage:
-      statut_occupation_logement: locataire_vide
-      personne_de_reference: couple1
-      conjoint: couple2
-      enfants: [enfant1, enfant2]
-    individus:
-      couple1:
-        age: 55
-        salaire_net:
-          2016-01: 4100
-      couple2:
-        age: 55
-        chomage_net:
-          2016-01: 400
-      enfant1:
-        age: 5
-      enfant2:
-        age: 9
-        handicap: true
-    foyers_fiscaux:
-      foyer_fiscal_0:
-        declarants:
-        - couple1
-        - couple2
-        personnes_a_charge:
-        - enfant1
-        - enfant2
+    parisien: true
+    paje_clca:
+      2016-01: 1000
+    paris_base_ressources_couple:
+      2016-01: 4500
+    paris_nb_enfants_handicapes: 1
   output:
-    paris_logement_aspeh: 153
+    paris_logement_aspeh: 0
 
-- name: Famille éligible pour l'allocation de soutien aux parents d’enfants handicapés
+- name: Famille avec 2 enfants éligible à l'allocation de soutien aux parents d’enfants handicapés
   period: 2016-02
   input:
-    famille:
-      parents: [couple1, couple2]
-      enfants: [enfant1, enfant2]
-      parisien: true
-      paje_clca: 100
-    menage:
-      statut_occupation_logement: locataire_vide
-      personne_de_reference: couple1
-      conjoint: couple2
-      enfants: [enfant1, enfant2]
-    individus:
-      couple1:
-        age: 55
-        handicap: true
-        salaire_net:
-          2016-01: 4100
-      couple2:
-        age: 55
-        chomage_net:
-          2016-01: 400
-      enfant1:
-        age: 5
-        handicap: true
-      enfant2:
-        age: 9
-        handicap: true
-    foyers_fiscaux:
-      foyer_fiscal_0:
-        declarants:
-        - couple1
-        - couple2
-        personnes_a_charge:
-        - enfant1
-        - enfant2
+    parisien: true
+    paris_logement_aspeh_base_ressources: 4500
+    paris_nb_enfants_handicapes: 2
   output:
     paris_logement_aspeh: 306

--- a/tests/unittests/paris.yaml
+++ b/tests/unittests/paris.yaml
@@ -10,7 +10,7 @@
       aide_logement: # ne doit pas être pris en compte
         2019-01: 15
       rsa:
-        2018-12: 18
+        2019-01: 18
     individus:
       parent1:
         ass:
@@ -62,7 +62,7 @@
       enfants: [enfant1]
   output:
     paris_base_ressources_famille: 
-      2019-01: 28
+      2019-01: 10 + 18
     paris_base_ressources_couple:
       2019-01: 702
     paris_base_ressources_foyer:

--- a/tests/unittests/paris_logement.yaml
+++ b/tests/unittests/paris_logement.yaml
@@ -44,7 +44,7 @@
     handicap: true
     statut_occupation_logement: locataire_vide
     loyer: 550
-    salaire_net:
+    paris_base_ressources_foyer:
       2016-01: 600
   output:
     paris_logement: 84
@@ -58,7 +58,7 @@
     handicap: true
     statut_occupation_logement: locataire_vide
     loyer: 550
-    salaire_net:
+    paris_base_ressources_foyer:
       2016-01: 800
   output:
     paris_logement: 84
@@ -108,6 +108,9 @@
     parisien: true
     statut_occupation_logement: locataire_vide
     loyer: 350
+    paris_base_ressources_famille:
+      2016-01: 0
+      2016-02: 0
   output:
     paris_logement: 77.839
 
@@ -121,6 +124,8 @@
     handicap: true
     statut_occupation_logement: locataire_vide
     loyer: 550
+    paris_base_ressources_famille:
+      2016-01: 0
   output:
     paris_logement: 84
 
@@ -136,6 +141,8 @@
     loyer: 550
     aah:
       2016-01: 800
+    paris_base_ressources_famille:
+      2016-01: 0
   output:
     paris_logement: 95
 
@@ -166,6 +173,8 @@
     aah:
       2016-01: 800
     loyer: 550
+    paris_base_ressources_famille:
+      2016-01: 0
   output:
     paris_logement: 84
 
@@ -337,6 +346,9 @@
       parents: [parent1, parent2]
       enfants: [enfant1, enfant2]
       parisien: true
+      paris_base_ressources_famille:
+        2016-01: 0
+        2016-02: 0
     menage:
       statut_occupation_logement: locataire_vide
       personne_de_reference: parent1
@@ -405,6 +417,8 @@
     famille:
       parents: [parent1, parent2]
       parisien: true
+      paris_base_ressources_famille:
+        2016-01: 0
     menage:
       statut_occupation_logement: locataire_vide
       personne_de_reference: parent1
@@ -440,6 +454,9 @@
       parents: [parent1, parent2]
       enfants: [enfant1, enfant2]
       parisien: true
+      paris_base_ressources_famille:
+        2016-01: 0
+        2016-02: 0
     menage:
       statut_occupation_logement: locataire_vide
       personne_de_reference: parent1
@@ -517,23 +534,10 @@
     loyer: 550
     aide_logement:
       2016-01: 200
+    paris_base_ressources_famille:
+      2016-01: 0
     salaire_net:
       2016-01: 850
-  output:
-    paris_logement: 84
-
-- name: Personne éligible au PL car ressources trop bas
-  description: Paris Logement Parisien en difficulté
-  period: 2016-02
-  input:
-    age: 45
-    parisien: true
-    statut_occupation_logement: locataire_vide
-    loyer: 550
-    aide_logement:
-      2016-01: 200
-    rsa:
-      2016-01: 450
   output:
     paris_logement: 84
 

--- a/tests/unittests/paris_logement_famille.yaml
+++ b/tests/unittests/paris_logement_famille.yaml
@@ -124,6 +124,7 @@
       enfants: [enfant1, enfant2]
       parisien: true
       en_couple: true
+      paris_base_ressources_foyer: 1900
     menage:
       statut_occupation_logement: proprietaire
       personne_de_reference: parent1
@@ -133,8 +134,6 @@
     individus:
       parent1:
         age: 55
-        salaire_net:
-          2016-01: 1900
       parent2:
         age: 55
       enfant1:
@@ -268,6 +267,7 @@
       enfants: [enfant1, enfant2]
       parisien: true
       en_couple: true
+      paris_base_ressources_foyer: 1900
     menage:
       statut_occupation_logement: locataire_vide
       personne_de_reference: parent1
@@ -277,8 +277,6 @@
     individus:
       parent1:
         age: 55
-        salaire_net:
-          2016-01: 1900
       parent2:
         age: 55
       enfant1:

--- a/tests/unittests/paris_solidarite.yaml
+++ b/tests/unittests/paris_solidarite.yaml
@@ -43,6 +43,7 @@
     handicap: true
     loyer: 600
     chomage_net: 600
+    paris_base_ressources_famille: 0
   output:
     paris_logement_psol: 92.35
 
@@ -156,6 +157,7 @@
     handicap: true
     aah: 500
     salaire_net: 80
+    paris_base_ressources_famille: 0
   output:
     paris_logement_psol: 92.35
 

--- a/tests/unittests/paris_solidarite_2018.yaml
+++ b/tests/unittests/paris_solidarite_2018.yaml
@@ -42,6 +42,7 @@
     handicap: true
     loyer: 600
     chomage_net: 600
+    paris_base_ressources_famille: 0
   output:
     paris_logement_psol: 96
 
@@ -152,6 +153,7 @@
     handicap: true
     aah: 500
     salaire_net: 80
+    paris_base_ressources_famille: 0
   output:
     paris_logement_psol: 96
 
@@ -330,6 +332,7 @@
       parents: [parent]
       enfants: [enfant1]
       parisien: true
+      paris_base_ressources_famille: 0
     menage:
       statut_occupation_logement: locataire_vide
       personne_de_reference: parent


### PR DESCRIPTION
Je n'ai pas trouvé de bonne raison à utiliser une période différente pour le RSA que celle de l'ASPA.