### PR TITLE
Mise à jour et compatibilité avec OpenFisca-France jusqu'à la version 176.0.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name="Openfisca-Paris",
-    version="5.5.14",
+    version="5.5.15",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
     classifiers=[
@@ -25,7 +25,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'OpenFisca-Core >= 43, < 45',
-        'OpenFisca-France >= 169.0.0, < 176.0.0',
+        'OpenFisca-France >= 169.0.0, < 177.0.0',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
- Relève la borne maximale d'OpenFisca-France dans setup.py (< 176.0.0 -> < 177.0.0) pour accepter la version 176.0.7
- Bump de version du package a 5.5.15 (necessaire pour que le check `check-version` de la CI passe)
- Remplace #178